### PR TITLE
adding active time for powerups

### DIFF
--- a/Assets/characters/player/PlayerScript.cs
+++ b/Assets/characters/player/PlayerScript.cs
@@ -175,5 +175,9 @@ public class PlayerScript : MonoBehaviour
 
         animator.SetBool("hasPower", true);
         animator.SetBool(getPowerName(newPower), true);
+        Invoke("ResetPowers", 5f);
+    }
+    void ResetPowers(){
+        ChangePower(DragonPower.STARNDARD_POWER);
     }
 }


### PR DESCRIPTION
Adiciona duração ativa para power-ups

Implementado temporizador para limitar o tempo de efeito dos power-ups.

Utilizado Invoke/Coroutine para desativar automaticamente após o tempo definido.

Pode ser configurado individualmente para diferentes tipos de power-up.